### PR TITLE
Require Python 3.6+ for larq to be installed

### DIFF
--- a/pydocmd.yml
+++ b/pydocmd.yml
@@ -37,7 +37,7 @@ pages:
   - Examples:
       - Introduction to Larq: examples/mnist.ipynb << examples/mnist.ipynb
       - Binarynet on CIFAR10: examples/binarynet_cifar10.ipynb << examples/binarynet_cifar10.ipynb
-  - Documenation:
+  - Documentation:
       - Quantized Layers: layers.md
       - Quantizers: quantizers.md
       - Activations: activations.md
@@ -48,6 +48,7 @@ pages:
 
 headers: markdown
 repo_url: https://github.com/plumerai/larq
+repo_name: plumerai/larq
 edit_uri: ""
 theme:
   name: material

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ def readme():
 setup(
     name="larq",
     version="0.1.0",
+    python_requires=">=3.6",
     author="Plumerai",
     author_email="lukas@plumerai.co.uk",
     description="An Open Source Machine Learning Library for Training Binarized Neural Networks",


### PR DESCRIPTION
I think after this we should publish a tiny patch release 0.1.1 and remove 0.1.0 from pypi so people will get a proper error message if they try to install it on Python 3.5 or earlier.