### PR TITLE
Tests: Compute gradient in eager mode

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,5 @@
 [run]
 omit =
     *_test.py
+    larq/optimizers.py
+    larq/callbacks.py

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,10 +16,10 @@ jobs:
         Python37:
           python.version: "3.7"
           tensorflow.version: "1.13.1"
-          coverage: "true"
         Python37TF2:
           python.version: "3.7"
           tensorflow.version: "2.0.0-alpha0"
+          coverage: "true"
 
     steps:
       - task: UsePythonVersion@0

--- a/larq/quantizers_test.py
+++ b/larq/quantizers_test.py
@@ -48,9 +48,8 @@ def test_ste_grad():
         return 0.0
 
     x = np.random.uniform(-2, 2, (8, 3, 3, 16))
-    tf_x = tf.constant(x)
+    tf_x = tf.Variable(x)
     with tf.GradientTape() as tape:
-        tape.watch(tf_x)
         activation = lq.quantizers.ste_sign(tf_x)
     grad = tape.gradient(activation, tf_x)
     np.testing.assert_allclose(grad.numpy(), ste_grad(x))
@@ -65,9 +64,8 @@ def test_approx_sign_grad():
         return 0.0
 
     x = np.random.uniform(-2, 2, (8, 3, 3, 16))
-    tf_x = tf.constant(x)
+    tf_x = tf.Variable(x)
     with tf.GradientTape() as tape:
-        tape.watch(tf_x)
         activation = lq.quantizers.approx_sign(tf_x)
     grad = tape.gradient(activation, tf_x)
     np.testing.assert_allclose(grad.numpy(), approx_sign_grad(x))


### PR DESCRIPTION
With this we can get rid of `tf.tes.TestCase` and are able to run the tests on TF 2. I also with it's a bit easier to write the tests in a functional style and in eager mode (helps a lot with debugging).

These tests are skipped by default when eager execution is disabled meaning we need run `tf.enable_eager_execution()` when developing with TF 1.

/cc @koenhelwegen 