### PR TITLE
Plot output and gradients of activations and quantizers in docs

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -52,3 +52,15 @@ jobs:
           codeCoverageTool: Cobertura
           summaryFileLocation: "$(System.DefaultWorkingDirectory)/**/coverage.xml"
           reportDirectory: "$(System.DefaultWorkingDirectory)/**/htmlcov"
+
+      - script: |
+          pip install nbconvert git+https://github.com/lgeiger/pydoc-markdown.git
+          pip install -e .[docs]
+        displayName: "Install docs dependencies"
+        condition: eq(variables['coverage'], 'true')
+
+      - script: |
+          python generate_api_docs.py
+          mkdocs build
+        displayName: "Build docs"
+        condition: eq(variables['coverage'], 'true')

--- a/larq/activations.py
+++ b/larq/activations.py
@@ -28,8 +28,10 @@ from larq import utils
 
 @utils.register_keras_custom_object
 def hard_tanh(x):
-    r"""Hard tanh activation function.
-    \\[\sigma(x) = \mathrm{Clip}(x, −1, 1)\\]
+    """Hard tanh activation function.
+    ```plot-activation
+    activations.hard_tanh
+    ```
 
     # Arguments
     x: Input tensor.
@@ -44,6 +46,10 @@ def hard_tanh(x):
 def leaky_tanh(x, alpha=0.2):
     r"""Leaky tanh activation function.
     Similar to hard tanh, but with non-zero slopes as in leaky ReLU.
+
+    ```plot-activation
+    activations.leaky_tanh
+    ```
 
     # Arguments
     x: Input tensor.

--- a/larq/quantizers.py
+++ b/larq/quantizers.py
@@ -45,6 +45,10 @@ def ste_sign(x):
       0 & \left|x\right| > 1
     \end{cases}\\]
 
+    ```plot-activation
+    quantizers.ste_sign
+    ```
+
     # Arguments
     x: Input tensor.
 
@@ -66,6 +70,9 @@ def magnitude_aware_sign(x):
     r"""
     Magnitude-aware sign for Bi-Real Net.
 
+    ```plot-activation
+    quantizers.magnitude_aware_sign
+    ```
 
     # Arguments
     x: Input tensor
@@ -93,8 +100,8 @@ def approx_sign(x):
     q(x) = \begin{cases}
       -1 & x < 0 \\\
       1 & x \geq 0
-   \end{cases}
-   \\]
+    \end{cases}
+    \\]
 
     The gradient is estimated using the ApproxSign method.
     \\[\frac{\partial q(x)}{\partial x} = \begin{cases}
@@ -102,6 +109,10 @@ def approx_sign(x):
       0 & \left|x\right| > 1
     \end{cases}
     \\]
+
+    ```plot-activation
+    quantizers.approx_sign
+    ```
 
     # Arguments
     x: Input tensor.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -46,7 +46,11 @@ extra:
 markdown_extensions:
   - admonition
   - codehilite
-  - pymdownx.superfences
+  - pymdownx.superfences:
+      custom_fences:
+        - name: plot-activation
+          class: larq-activation
+          format: !!python/name:plot_activation.html_format
   - pymdownx.arithmatex
   - toc:
       permalink: true

--- a/plot_activation.py
+++ b/plot_activation.py
@@ -1,13 +1,24 @@
 from functools import reduce
-import matplotlib
+import matplotlib as mpl
+import matplotlib.pyplot as plt
 import numpy as np
 import larq as lq
 import tensorflow as tf
-import matplotlib.pyplot as plt
 from io import StringIO
 from scour import scour
 
-matplotlib.use("Agg")
+mpl.use("Agg")
+mpl.rcParams["svg.fonttype"] = "none"
+mpl.rcParams["font.size"] = 11
+mpl.rcParams["axes.titlesize"] = 12
+mpl.rcParams["font.sans-serif"] = [
+    "Roboto",
+    "Helvetica Neue",
+    "Helvetica",
+    "Arial",
+    "sans-serif",
+]
+
 try:
     tf.enable_eager_execution()
 except:
@@ -28,7 +39,9 @@ def plot(function):
     ax1.plot(x, y, color="#3f51b5")
     ax1.set_xlabel("x")
     ax1.set_ylabel("y")
+    ax1.set_title("Forward pass")
     ax2.plot(x, dy, color="#3f51b5")
+    ax2.set_title("Backward pass")
     ax2.set_xlabel("x")
     ax2.set_ylabel("dy / dx")
     fig.tight_layout(pad=0.7)
@@ -38,5 +51,5 @@ def plot(function):
 def html_format(source, language, css_class, options, md):
     fig = plot(reduce(getattr, [lq, *source.split(".")]))
     tmp = StringIO()
-    fig.savefig(tmp, format="svg", bbox_inches="tight")
+    fig.savefig(tmp, format="svg", bbox_inches="tight", pad_inches=0)
     return scour.scourString(tmp.getvalue())

--- a/plot_activation.py
+++ b/plot_activation.py
@@ -5,6 +5,7 @@ import larq as lq
 import tensorflow as tf
 import matplotlib.pyplot as plt
 from io import StringIO
+from scour import scour
 
 matplotlib.use("Agg")
 try:
@@ -38,4 +39,4 @@ def html_format(source, language, css_class, options, md):
     fig = plot(reduce(getattr, [lq, *source.split(".")]))
     tmp = StringIO()
     fig.savefig(tmp, format="svg", bbox_inches="tight")
-    return tmp.getvalue()
+    return scour.scourString(tmp.getvalue())

--- a/plot_activation.py
+++ b/plot_activation.py
@@ -1,0 +1,41 @@
+from functools import reduce
+import matplotlib
+import numpy as np
+import larq as lq
+import tensorflow as tf
+import matplotlib.pyplot as plt
+from io import StringIO
+
+matplotlib.use("Agg")
+try:
+    tf.enable_eager_execution()
+except:
+    pass
+
+
+def calculate_activation(function, x):
+    tf_x = tf.Variable(x)
+    with tf.GradientTape() as tape:
+        activation = function(tf_x)
+    return activation.numpy(), tape.gradient(activation, tf_x).numpy()
+
+
+def plot(function):
+    x = np.linspace(-2, 2, 500)
+    y, dy = calculate_activation(function, x)
+    fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(8, 3))
+    ax1.plot(x, y, color="#3f51b5")
+    ax1.set_xlabel("x")
+    ax1.set_ylabel("y")
+    ax2.plot(x, dy, color="#3f51b5")
+    ax2.set_xlabel("x")
+    ax2.set_ylabel("dy / dx")
+    fig.tight_layout(pad=0.7)
+    return fig
+
+
+def html_format(source, language, css_class, options, md):
+    fig = plot(reduce(getattr, [lq, *source.split(".")]))
+    tmp = StringIO()
+    fig.savefig(tmp, format="svg", bbox_inches="tight")
+    return tmp.getvalue()

--- a/setup.py
+++ b/setup.py
@@ -24,9 +24,12 @@ setup(
         "tensorflow_gpu": ["tensorflow-gpu>=1.13.1"],
         "test": ["absl-py>=0.7.0", "pytest>=4.3.1", "pytest-cov>=2.6.1"],
         "docs": [
-            "mkdocs-material>=4.1.0",
+            "mkdocs>=1.0.4",
+            "mkdocs-material>=4.1.2",
             "pymdown-extensions>=6.0",
             "mknotebooks>=0.1.5",
+            "matplotlib>=3.0.3",
+            "scour>=0.37",
         ],
     },
     classifiers=[


### PR DESCRIPTION
This adds simple matplotlib plots to our documentation, which will also add an additional sanity check for the math:
<img width="1552" alt="Bildschirmfoto 2019-04-23 um 21 06 53" src="https://user-images.githubusercontent.com/13285808/56612325-fdc91d00-660b-11e9-995f-f9effbba49bf.png">