### PR TITLE
Add test to make sure quantizers can be used as activations

### DIFF
--- a/larq/quantizers.py
+++ b/larq/quantizers.py
@@ -86,10 +86,9 @@ def magnitude_aware_sign(x):
       Algorithm](https://arxiv.org/abs/1808.00278)
 
     """
-    scale_factor = tf.stop_gradient(
-        tf.reduce_mean(tf.abs(x), axis=list(range(len(x.shape) - 1)))
-    )
-    return scale_factor * ste_sign(x)
+    scale_factor = tf.reduce_mean(tf.abs(x), axis=list(range(len(x.shape) - 1)))
+
+    return tf.stop_gradient(scale_factor) * ste_sign(x)
 
 
 @utils.register_keras_custom_object

--- a/larq/quantizers_test.py
+++ b/larq/quantizers_test.py
@@ -17,6 +17,18 @@ def test_serialization(name):
     assert fn == ref_fn
 
 
+@pytest.mark.parametrize("name", ["ste_sign", "approx_sign", "magnitude_aware_sign"])
+def test_serialization_as_activation(name):
+    fn = tf.keras.activations.get(name)
+    ref_fn = getattr(lq.quantizers, name)
+    assert fn == ref_fn
+    config = tf.keras.activations.serialize(fn)
+    fn = tf.keras.activations.deserialize(config)
+    assert fn == ref_fn
+    fn = tf.keras.activations.get(ref_fn)
+    assert fn == ref_fn
+
+
 def test_invalid_usage():
     with pytest.raises(ValueError):
         lq.quantizers.get(42)


### PR DESCRIPTION
This makes sure the following syntax works:

```python
tf.keras.layers.Activation("ste_sign")
Layer(activation="ste_sign")
```