### PR TITLE
Display links to source code

### DIFF
--- a/docs/custom.css
+++ b/docs/custom.css
@@ -1,0 +1,3 @@
+.code-link::before {
+  content: "</>";
+}

--- a/generate_api_docs.py
+++ b/generate_api_docs.py
@@ -13,7 +13,8 @@ from pydocmd.preprocessor import Preprocessor
 
 def callable_to_source_link(obj, scope):
     path = scope.__file__.lstrip(".")
-    line = inspect.getsourcelines(obj)[-1]
+    source = inspect.getsourcelines(obj)
+    line = source[-1] + 1 if source[0][0].startswith("@") else source[-1]
     link = f"https://github.com/plumerai/larq/blob/master{path}#L{line}"
     return f'<a class="headerlink code-link" style="float:right;" href="{link}" title="Source Code"></a>'
 

--- a/generate_api_docs.py
+++ b/generate_api_docs.py
@@ -1,5 +1,6 @@
 """https://github.com/NiklasRosenstein/pydoc-markdown/blob/master/pydocmd/__main__.py"""
 
+import inspect
 import os
 import sys
 import yaml
@@ -8,6 +9,22 @@ from pydocmd.document import Index
 from pydocmd.imp import dir_object
 from pydocmd.loader import PythonLoader
 from pydocmd.preprocessor import Preprocessor
+
+
+def callable_to_source_link(obj, scope):
+    path = scope.__file__.lstrip(".")
+    line = inspect.getsourcelines(obj)[-1]
+    link = f"https://github.com/plumerai/larq/blob/master{path}#L{line}"
+    return f'<a class="headerlink code-link" style="float:right;" href="{link}" title="Source Code"></a>'
+
+
+class PythonLoaderWithSource(PythonLoader):
+    def load_section(self, section):
+        super().load_section(section)
+        obj = section.loader_context["obj"]
+        if callable(obj):
+            scope = section.loader_context["scope"]
+            section.title += callable_to_source_link(obj, scope)
 
 
 with open("apidocs.yml", "r") as stream:
@@ -54,7 +71,7 @@ for pages in api_structure:
         doc = index.new_document(fname)
         add_sections(doc, object_names)
 
-loader = PythonLoader({})
+loader = PythonLoaderWithSource({})
 preproc = Preprocessor({})
 
 preproc.link_lookup = {}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -58,6 +58,9 @@ markdown_extensions:
 extra_javascript:
   - "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-AMS_CHTML"
 
+extra_css:
+  - custom.css
+
 plugins:
   - search
   - mknotebooks:


### PR DESCRIPTION
This will add links to the source code on hover:
![Bildschirmfoto 2019-05-10 um 15 01 07](https://user-images.githubusercontent.com/13285808/57532967-9530ae80-7334-11e9-9f40-97252db7e94b.png)

~It's not perfect. For functions it links to the line of the decorator (one line above the actual function, also `inspect.unwrap` didn't help), but it's still a large improvement.~ fixed in 0ec98ba8f5fb5a6240df6e23575c2c5249f6267c
Fixes #88 