### PR TITLE
Change Top level docs structure

### DIFF
--- a/generate_api_docs.py
+++ b/generate_api_docs.py
@@ -16,7 +16,7 @@ def callable_to_source_link(obj, scope):
     source = inspect.getsourcelines(obj)
     line = source[-1] + 1 if source[0][0].startswith("@") else source[-1]
     link = f"https://github.com/plumerai/larq/blob/master{path}#L{line}"
-    return f'<a class="headerlink code-link" style="float:right;" href="{link}" title="Source Code"></a>'
+    return f'<a class="headerlink code-link" style="float:right;" href="{link}" title="Source code"></a>'
 
 
 class PythonLoaderWithSource(PythonLoader):

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,13 +2,10 @@ site_name: Larq
 site_description: "An Open Source Machine Learning Framework for Training Extreme Quantized Neural Networks"
 
 nav:
-  - Home:
-      - Getting Started: index.md
+  - Learn:
+      - Introduction: index.md
       - User Guide: guide.md
-      - Developer Guide:
-          - Contributing Guide: contributing.md
-          - Code of Conduct: code_of_conduct.md
-  - Examples:
+  - Tutorials:
       - Introduction to BNNs with Larq: examples/mnist.ipynb
       - BinaryNet on CIFAR10: examples/binarynet_cifar10.ipynb
       - BinaryNet on CIFAR10 (Advanced): examples/binarynet_advanced_cifar10.ipynb
@@ -20,6 +17,9 @@ nav:
       - Callbacks: api/callbacks.md
       - Optimizers: api/optimizers.md
       - Models: api/models.md
+  - Community:
+      - Contributing Guide: contributing.md
+      - Code of Conduct: code_of_conduct.md
 
 repo_url: https://github.com/plumerai/larq
 repo_name: plumerai/larq


### PR DESCRIPTION
This should make the structure of the docs a bit easier to understand.
![Bildschirmfoto 2019-06-03 um 14 10 54](https://user-images.githubusercontent.com/13285808/58804307-78bd2480-8609-11e9-96f2-559d875f3306.png)

Changes:
- New top level tab "Community" which includes the former developer guide
- Home -> Learn
- Getting Started -> Introduction
- Examples -> Tutorials