### PR TITLE
Prevent QuantizedLogger from adding nodes to the graph during training

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,7 +18,7 @@ jobs:
           tensorflow: "tensorflow==1.13.1"
         Python37TF2:
           python.version: "3.7"
-          tensorflow: "tf-nightly-2.0-preview"
+          tensorflow: "tensorflow==2.0.0b0"
           coverage: "true"
 
     steps:

--- a/larq/layers.py
+++ b/larq/layers.py
@@ -37,7 +37,8 @@ class QuantizerBase(tf.keras.layers.Layer):
     @property
     def quantized_weights(self):
         if self.kernel_quantizer and self.kernel is not None:
-            return [self.kernel_quantizer(self.kernel)]
+            with tf.name_scope(self.name):
+                return [self.kernel_quantizer(self.kernel)]
         return []
 
     @property
@@ -104,12 +105,17 @@ class QuantizerSeparableBase(tf.keras.layers.Layer):
 
     @property
     def quantized_weights(self):
-        quantized_weights = []
-        if self.depthwise_quantizer and self.depthwise_kernel is not None:
-            quantized_weights.append(self.depthwise_quantizer(self.depthwise_kernel))
-        if self.pointwise_quantizer and self.pointwise_kernel is not None:
-            quantized_weights.append(self.pointwise_quantizer(self.pointwise_kernel))
-        return quantized_weights
+        with tf.name_scope(self.name):
+            quantized_weights = []
+            if self.depthwise_quantizer and self.depthwise_kernel is not None:
+                quantized_weights.append(
+                    self.depthwise_quantizer(self.depthwise_kernel)
+                )
+            if self.pointwise_quantizer and self.pointwise_kernel is not None:
+                quantized_weights.append(
+                    self.pointwise_quantizer(self.pointwise_kernel)
+                )
+            return quantized_weights
 
     @property
     def quantized_latent_weights(self):


### PR DESCRIPTION
#96 Prevented unnecessary nodes from being created during layer build time if the logger isn't used. Unfortunately this has the effect that `QuantizedLogger` constantly adds new nodes to the graph during logging since the `quantized_weights` property is now layzily computed and doesn't reuse the already existing ops in the graph (I don't know if there is a way to force this reuse, `tf.variable_scope(..., reuse=True)` only works for variables).

This PR fixes the problem by only calling `layer.quantized_weights` once during callback initialization.

In the future I'd really like to do this in a proper way. Keras layers have an [`add_metric` method](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/keras/engine/base_layer_test.py#L982-L992) that would allow us to add metrics like this. Unfortunately the metrics we are interested in are stateful since they compare pre and post-update states so we need to properly benchmark this to see if a solution like this would come with performance penalties sinc metrics are accumulated at each update step.