### PR TITLE
Add layer metrics to replace quant logger callback

### DIFF
--- a/larq/callbacks_test.py
+++ b/larq/callbacks_test.py
@@ -7,7 +7,6 @@ from larq.callbacks import HyperparameterScheduler
 
 from tensorflow import keras
 from tensorflow.python.keras import testing_utils
-from tensorflow.python.keras import keras_parameterized
 
 
 class LogHistory(tf.keras.callbacks.Callback):
@@ -26,8 +25,7 @@ class LogHistory(tf.keras.callbacks.Callback):
         self._store_logs(self.epochs, epoch, logs)
 
 
-@keras_parameterized.run_all_keras_modes
-class LayersTest(keras_parameterized.TestCase):
+class TestQuantizationLogger:
     def test_quantization_logger(self):
         model = tf.keras.models.Sequential(
             [

--- a/larq/layers.py
+++ b/larq/layers.py
@@ -7,7 +7,6 @@ is equivalent to a full precision layer.
 """
 
 import logging
-from distutils.version import LooseVersion
 import tensorflow as tf
 from larq import quantizers, utils, metrics
 
@@ -17,9 +16,7 @@ log = logging.getLogger(__name__)
 def _supports_metrics():
     # TensorFlow 1.13 does not support adding an aggregated metric tensor in
     # `tf.keras.layers.Layer.call` in eager execution.
-    return not (
-        LooseVersion(tf.__version__) < LooseVersion("1.14.0") and tf.executing_eagerly()
-    )
+    return utils.tf_1_14_or_newer() or not tf.executing_eagerly()
 
 
 class QuantizerBase(tf.keras.layers.Layer):

--- a/larq/layers.py
+++ b/larq/layers.py
@@ -21,20 +21,14 @@ class QuantizerBase(tf.keras.layers.Layer):
     equivalent to `Layer`.
     """
 
-    def __init__(
-        self,
-        *args,
-        input_quantizer=None,
-        kernel_quantizer=None,
-        metrics=["mean_changed_values"],
-        **kwargs,
-    ):
-        super().__init__(*args, **kwargs)
+    def __init__(self, *args, input_quantizer=None, kernel_quantizer=None, **kwargs):
+        # This is currently undocumented until we have explored better options
+        self._custom_metrics = kwargs.pop("metrics", ["mean_changed_values"])
 
-        self._custom_metrics = metrics
         self.input_quantizer = quantizers.get(input_quantizer)
         self.kernel_quantizer = quantizers.get(kernel_quantizer)
 
+        super().__init__(*args, **kwargs)
         if kernel_quantizer and not self.kernel_constraint:
             log.warning(
                 "Using a weight quantizer without setting `kernel_constraint` "

--- a/larq/layers.py
+++ b/larq/layers.py
@@ -71,7 +71,7 @@ class QuantizerBase(tf.keras.layers.Layer):
         if self.kernel_quantizer:
             full_precision_kernel = self.kernel
             quantized_kernel = self.kernel_quantizer(self.kernel)
-            if "mean_changed_values" in self._custom_metrics and _supports_metrics():
+            if hasattr(self, "mean_changed_values"):
                 self.add_metric(self.mean_changed_values(quantized_kernel))
             self.kernel = quantized_kernel
 
@@ -170,7 +170,7 @@ class QuantizerSeparableBase(tf.keras.layers.Layer):
         if self.depthwise_quantizer:
             full_precision_depthwise_kernel = self.depthwise_kernel
             depthwise_quantized_kernel = self.depthwise_quantizer(self.depthwise_kernel)
-            if "mean_changed_values" in self._custom_metrics:
+            if hasattr(self, "depthwise_mean_changed_values"):
                 self.add_metric(
                     self.depthwise_mean_changed_values(depthwise_quantized_kernel)
                 )
@@ -178,7 +178,7 @@ class QuantizerSeparableBase(tf.keras.layers.Layer):
         if self.pointwise_quantizer:
             full_precision_pointwise_kernel = self.pointwise_kernel
             pointwise_quantized_kernel = self.pointwise_quantizer(self.pointwise_kernel)
-            if "mean_changed_values" in self._custom_metrics:
+            if hasattr(self, "pointwise_mean_changed_values"):
                 self.add_metric(
                     self.pointwise_mean_changed_values(pointwise_quantized_kernel)
                 )

--- a/larq/layers.py
+++ b/larq/layers.py
@@ -102,7 +102,7 @@ class QuantizerSeparableBase(tf.keras.layers.Layer):
         input_quantizer=None,
         depthwise_quantizer=None,
         pointwise_quantizer=None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(*args, **kwargs)
         self.input_quantizer = quantizers.get(input_quantizer)
@@ -255,7 +255,7 @@ class QuantDense(QuantizerBase, tf.keras.layers.Dense):
         activity_regularizer=None,
         kernel_constraint=None,
         bias_constraint=None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(
             units,
@@ -270,7 +270,7 @@ class QuantDense(QuantizerBase, tf.keras.layers.Dense):
             activity_regularizer=activity_regularizer,
             kernel_constraint=kernel_constraint,
             bias_constraint=bias_constraint,
-            **kwargs
+            **kwargs,
         )
 
 
@@ -349,7 +349,7 @@ class QuantConv1D(QuantizerBase, tf.keras.layers.Conv1D):
         activity_regularizer=None,
         kernel_constraint=None,
         bias_constraint=None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(
             filters,
@@ -369,7 +369,7 @@ class QuantConv1D(QuantizerBase, tf.keras.layers.Conv1D):
             activity_regularizer=activity_regularizer,
             kernel_constraint=kernel_constraint,
             bias_constraint=bias_constraint,
-            **kwargs
+            **kwargs,
         )
 
 
@@ -458,7 +458,7 @@ class QuantConv2D(QuantizerBase, tf.keras.layers.Conv2D):
         activity_regularizer=None,
         kernel_constraint=None,
         bias_constraint=None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(
             filters,
@@ -478,7 +478,7 @@ class QuantConv2D(QuantizerBase, tf.keras.layers.Conv2D):
             activity_regularizer=activity_regularizer,
             kernel_constraint=kernel_constraint,
             bias_constraint=bias_constraint,
-            **kwargs
+            **kwargs,
         )
 
 
@@ -573,7 +573,7 @@ class QuantConv3D(QuantizerBase, tf.keras.layers.Conv3D):
         activity_regularizer=None,
         kernel_constraint=None,
         bias_constraint=None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(
             filters,
@@ -593,7 +593,7 @@ class QuantConv3D(QuantizerBase, tf.keras.layers.Conv3D):
             activity_regularizer=activity_regularizer,
             kernel_constraint=kernel_constraint,
             bias_constraint=bias_constraint,
-            **kwargs
+            **kwargs,
         )
 
 
@@ -679,7 +679,7 @@ class QuantSeparableConv1D(QuantizerSeparableBase, tf.keras.layers.SeparableConv
         depthwise_constraint=None,
         pointwise_constraint=None,
         bias_constraint=None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(
             filters,
@@ -704,7 +704,7 @@ class QuantSeparableConv1D(QuantizerSeparableBase, tf.keras.layers.SeparableConv
             depthwise_constraint=depthwise_constraint,
             pointwise_constraint=pointwise_constraint,
             bias_constraint=bias_constraint,
-            **kwargs
+            **kwargs,
         )
 
 
@@ -806,7 +806,7 @@ class QuantSeparableConv2D(QuantizerSeparableBase, tf.keras.layers.SeparableConv
         depthwise_constraint=None,
         pointwise_constraint=None,
         bias_constraint=None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(
             filters,
@@ -831,7 +831,7 @@ class QuantSeparableConv2D(QuantizerSeparableBase, tf.keras.layers.SeparableConv
             depthwise_constraint=depthwise_constraint,
             pointwise_constraint=pointwise_constraint,
             bias_constraint=bias_constraint,
-            **kwargs
+            **kwargs,
         )
 
 
@@ -933,7 +933,7 @@ class QuantConv2DTranspose(QuantizerBase, tf.keras.layers.Conv2DTranspose):
         activity_regularizer=None,
         kernel_constraint=None,
         bias_constraint=None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(
             filters,
@@ -953,7 +953,7 @@ class QuantConv2DTranspose(QuantizerBase, tf.keras.layers.Conv2DTranspose):
             activity_regularizer=activity_regularizer,
             kernel_constraint=kernel_constraint,
             bias_constraint=bias_constraint,
-            **kwargs
+            **kwargs,
         )
 
 
@@ -1054,7 +1054,7 @@ class QuantConv3DTranspose(QuantizerBase, tf.keras.layers.Conv3DTranspose):
         activity_regularizer=None,
         kernel_constraint=None,
         bias_constraint=None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(
             filters,
@@ -1073,7 +1073,7 @@ class QuantConv3DTranspose(QuantizerBase, tf.keras.layers.Conv3DTranspose):
             activity_regularizer=activity_regularizer,
             kernel_constraint=kernel_constraint,
             bias_constraint=bias_constraint,
-            **kwargs
+            **kwargs,
         )
 
 
@@ -1179,7 +1179,7 @@ class QuantLocallyConnected1D(QuantizerBase, tf.keras.layers.LocallyConnected1D)
         kernel_constraint=None,
         bias_constraint=None,
         implementation=1,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(
             filters,
@@ -1199,7 +1199,7 @@ class QuantLocallyConnected1D(QuantizerBase, tf.keras.layers.LocallyConnected1D)
             kernel_constraint=kernel_constraint,
             bias_constraint=bias_constraint,
             implementation=implementation,
-            **kwargs
+            **kwargs,
         )
 
 
@@ -1316,7 +1316,7 @@ class QuantLocallyConnected2D(QuantizerBase, tf.keras.layers.LocallyConnected2D)
         kernel_constraint=None,
         bias_constraint=None,
         implementation=1,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(
             filters,
@@ -1336,5 +1336,5 @@ class QuantLocallyConnected2D(QuantizerBase, tf.keras.layers.LocallyConnected2D)
             kernel_constraint=kernel_constraint,
             bias_constraint=bias_constraint,
             implementation=implementation,
-            **kwargs
+            **kwargs,
         )

--- a/larq/layers.py
+++ b/larq/layers.py
@@ -44,7 +44,9 @@ class QuantizerBase(tf.keras.layers.Layer):
     def build(self, input_shape):
         super().build(input_shape)
         if "mean_changed_values" in self._custom_metrics:
-            self.mean_changed_values = metrics.MeanChangedValues(self.kernel.shape)
+            self.mean_changed_values = metrics.MeanChangedValues(
+                self.kernel.shape, name=f"{self.name}/mean_changed_values"
+            )
 
     @property
     def quantized_weights(self):

--- a/larq/layers.py
+++ b/larq/layers.py
@@ -37,7 +37,7 @@ class QuantizerBase(tf.keras.layers.Layer):
 
     def build(self, input_shape):
         super().build(input_shape)
-        if "mean_changed_values" in self._custom_metrics:
+        if self.kernel_quantizer and "mean_changed_values" in self._custom_metrics:
             self.mean_changed_values = metrics.MeanChangedValues(
                 self.kernel.shape, name=f"{self.name}/mean_changed_values"
             )

--- a/larq/layers.py
+++ b/larq/layers.py
@@ -49,7 +49,7 @@ class QuantizerBase(tf.keras.layers.Layer):
             and _supports_metrics()
         ):
             self.mean_changed_values = metrics.MeanChangedValues(
-                self.kernel.shape, name=f"{self.name}/mean_changed_values"
+                values_shape=self.kernel.shape, name=f"{self.name}/mean_changed_values"
             )
 
     @property
@@ -132,12 +132,12 @@ class QuantizerSeparableBase(tf.keras.layers.Layer):
         if "mean_changed_values" in self._custom_metrics:
             if self.depthwise_quantizer:
                 self.depthwise_mean_changed_values = metrics.MeanChangedValues(
-                    self.depthwise_kernel.shape,
+                    values_shape=self.depthwise_kernel.shape,
                     name=f"{self.name}/depthwise_mean_changed_values",
                 )
             if self.pointwise_quantizer:
                 self.pointwise_mean_changed_values = metrics.MeanChangedValues(
-                    self.pointwise_kernel.shape,
+                    values_shape=self.pointwise_kernel.shape,
                     name=f"{self.name}/pointwise_mean_changed_values",
                 )
 

--- a/larq/layers_test.py
+++ b/larq/layers_test.py
@@ -4,9 +4,8 @@ from absl.testing import parameterized
 import larq as lq
 import pytest
 import inspect
-
+from larq import testing_utils
 from tensorflow.python.keras import keras_parameterized
-from tensorflow.python.keras import testing_utils
 
 
 def random_input(shape):

--- a/larq/metrics.py
+++ b/larq/metrics.py
@@ -32,12 +32,13 @@ class MeanChangedValues(tf.keras.metrics.Mean):
         super().__init__(name=name, dtype=dtype)
         self.values_dtype = tf.as_dtype(values_dtype)
         self.values_shape = tf.TensorShape(values_shape).as_list()
-        self._previous_values = self.add_weight(
-            "previous_values",
-            shape=values_shape,
-            dtype=self.values_dtype,
-            initializer=tf.keras.initializers.zeros,
-        )
+        with tf.name_scope(name):
+            self._previous_values = self.add_weight(
+                "previous_values",
+                shape=values_shape,
+                dtype=self.values_dtype,
+                initializer=tf.keras.initializers.zeros,
+            )
         self._size = np.prod(self.values_shape)
         self._built = False
 

--- a/larq/metrics.py
+++ b/larq/metrics.py
@@ -4,6 +4,25 @@ import numpy as np
 
 
 class MeanChangedValues(tf.keras.metrics.Mean):
+    """Computes the mean ration of changed values in a given tensor.
+
+    !!! example
+        ```python
+        m = metrics.MeanChangedValues()
+        m.update_state(1)
+        m.reset_states()
+        m.update_state(2)
+        m.update_state(1)
+        print('Final result: ', m.result().numpy())  # Final result: 0.5
+        ```
+
+    # Arguments
+    values_shape: Shape of the tensor for which to track changes.
+    values_dtype: Data type of the tensor for which to track changes.
+    name: Name of the metric.
+    dtype: Data type of the moving mean.
+    """
+
     def __init__(
         self,
         values_shape=(),

--- a/larq/metrics.py
+++ b/larq/metrics.py
@@ -3,12 +3,12 @@ from larq import utils
 import numpy as np
 
 
-class MeanChangedValues(tf.keras.metrics.Mean):
+class FlipRatio(tf.keras.metrics.Mean):
     """Computes the mean ration of changed values in a given tensor.
 
     !!! example
         ```python
-        m = metrics.MeanChangedValues(values_shape=(2,))
+        m = metrics.FlipRatio(values_shape=(2,))
         m.update_state((1, 1))  # result: 0
         m.update_state((2, 2))  # result: 1
         m.update_state((1, 2))  # result: 0.75
@@ -23,11 +23,7 @@ class MeanChangedValues(tf.keras.metrics.Mean):
     """
 
     def __init__(
-        self,
-        values_shape=(),
-        values_dtype="int8",
-        name="mean_changed_values",
-        dtype=None,
+        self, values_shape=(), values_dtype="int8", name="flip_ratio", dtype=None
     ):
         super().__init__(name=name, dtype=dtype)
         self.values_dtype = tf.as_dtype(values_dtype)
@@ -48,7 +44,7 @@ class MeanChangedValues(tf.keras.metrics.Mean):
             self._built = True
             return self._previous_values.assign(values)
         changed_values = tf.math.count_nonzero(tf.equal(self._previous_values, values))
-        metric_update_op = super(MeanChangedValues, self).update_state(
+        metric_update_op = super(FlipRatio, self).update_state(
             1 - (tf.cast(changed_values, self.dtype) / self._size)
         )
         with tf.control_dependencies([metric_update_op]):

--- a/larq/metrics.py
+++ b/larq/metrics.py
@@ -8,11 +8,11 @@ class MeanChangedValues(tf.keras.metrics.Mean):
 
     !!! example
         ```python
-        m = metrics.MeanChangedValues()
-        m.update_state(1)
-        m.update_state(2)
-        m.update_state(2)
-        print('Final result: ', m.result().numpy())  # Final result: 0.5
+        m = metrics.MeanChangedValues(values_shape=(2,))
+        m.update_state((1, 1))  # result: 0
+        m.update_state((2, 2))  # result: 1
+        m.update_state((1, 2))  # result: 0.75
+        print('Final result: ', m.result().numpy())  # Final result: 0.75
         ```
 
     # Arguments

--- a/larq/metrics.py
+++ b/larq/metrics.py
@@ -1,5 +1,5 @@
 import tensorflow as tf
-from distutils.version import LooseVersion
+from larq import utils
 import numpy as np
 
 
@@ -38,7 +38,18 @@ class MeanChangedValues(tf.keras.metrics.Mean):
         initializer=None,
         dtype=None,
     ):
-        if LooseVersion(tf.__version__) < LooseVersion("1.14.0"):
+        if utils.tf_1_14_or_newer():
+            return super().add_weight(
+                name=name,
+                shape=shape,
+                aggregation=aggregation,
+                synchronization=synchronization,
+                initializer=initializer,
+                dtype=dtype,
+            )
+        else:
+            # Call explicitely tf.keras.layers.Layer.add_weight because TF 1.13
+            # doesn't support setting a custom dtype
             return tf.keras.layers.Layer.add_weight(
                 self,
                 name=name,
@@ -50,11 +61,3 @@ class MeanChangedValues(tf.keras.metrics.Mean):
                 synchronization=synchronization,
                 aggregation=aggregation,
             )
-        return super().add_weight(
-            name=name,
-            shape=shape,
-            aggregation=aggregation,
-            synchronization=synchronization,
-            initializer=initializer,
-            dtype=dtype,
-        )

--- a/larq/metrics.py
+++ b/larq/metrics.py
@@ -2,8 +2,13 @@ import tensorflow as tf
 from larq import utils
 import numpy as np
 
+try:
+    from tensorflow.keras.metrics import Metric
+except:  # TensorFlow 1.13 doesn't export this as a public API
+    from tensorflow.python.keras.metrics import Metric
 
-class FlipRatio(tf.keras.metrics.Metric):
+
+class FlipRatio(Metric):
     """Computes the mean ration of changed values in a given tensor.
 
     !!! example

--- a/larq/metrics.py
+++ b/larq/metrics.py
@@ -60,7 +60,7 @@ class FlipRatio(Metric):
                 return self._previous_values.assign(values)
 
     def result(self):
-        return tf.div_no_nan(self.total, self.count - 1)
+        return tf.compat.v1.div_no_nan(self.total, self.count - 1)
 
     def reset_states(self):
         tf.keras.backend.batch_set_value(

--- a/larq/metrics.py
+++ b/larq/metrics.py
@@ -48,7 +48,7 @@ class MeanChangedValues(tf.keras.metrics.Mean):
             return self._previous_values.assign(values)
         changed_values = tf.math.count_nonzero(tf.equal(self._previous_values, values))
         metric_update_op = super(MeanChangedValues, self).update_state(
-            1 - (tf.cast(changed_values, tf.float32) / self._size)
+            1 - (tf.cast(changed_values, self.dtype) / self._size)
         )
         with tf.control_dependencies([metric_update_op]):
             return self._previous_values.assign(values)

--- a/larq/metrics.py
+++ b/larq/metrics.py
@@ -1,4 +1,5 @@
 import tensorflow as tf
+import distutils.version as version
 import numpy as np
 
 
@@ -26,4 +27,34 @@ class MeanChangedValues(tf.keras.metrics.Mean):
     def reset_states(self):
         tf.keras.backend.batch_set_value(
             [(v, 0) for v in self.variables if v != self._previous_values]
+        )
+
+    def add_weight(
+        self,
+        name,
+        shape=(),
+        aggregation=tf.VariableAggregation.SUM,
+        synchronization=tf.VariableSynchronization.ON_READ,
+        initializer=None,
+        dtype=None,
+    ):
+        if version.LooseVersion(tf.__version__) < version.LooseVersion("1.14.0"):
+            return tf.keras.layers.Layer.add_weight(
+                self,
+                name=name,
+                shape=shape,
+                dtype=self._dtype if dtype is None else dtype,
+                trainable=False,
+                initializer=initializer,
+                collections=[],
+                synchronization=synchronization,
+                aggregation=aggregation,
+            )
+        return super().add_weight(
+            name=name,
+            shape=shape,
+            aggregation=aggregation,
+            synchronization=synchronization,
+            initializer=initializer,
+            dtype=dtype,
         )

--- a/larq/metrics.py
+++ b/larq/metrics.py
@@ -6,7 +6,7 @@ import numpy as np
 class MeanChangedValues(tf.keras.metrics.Mean):
     def __init__(
         self,
-        values_shape=None,
+        values_shape=(),
         values_dtype="int8",
         name="mean_changed_values",
         dtype=None,
@@ -25,7 +25,9 @@ class MeanChangedValues(tf.keras.metrics.Mean):
     def update_state(self, values, sample_weight=None):
         values = tf.cast(values, self.values_dtype)
         changed_values = tf.math.count_nonzero(tf.equal(self._previous_values, values))
-        metric_update_op = super().update_state(changed_values / self._size)
+        metric_update_op = super().update_state(
+            1 - (tf.cast(changed_values, tf.float32) / self._size)
+        )
         with tf.control_dependencies([metric_update_op]):
             return self._previous_values.assign(values)
 

--- a/larq/metrics.py
+++ b/larq/metrics.py
@@ -1,0 +1,29 @@
+import tensorflow as tf
+import numpy as np
+
+
+class MeanChangedValues(tf.keras.metrics.Mean):
+    def __init__(
+        self, values_shape, values_dtype="int8", name="mean_changed_values", dtype=None
+    ):
+        super().__init__(name=name, dtype=dtype)
+        self._values_dtype = tf.as_dtype(values_dtype).name
+        self._previous_values = self.add_weight(
+            "previous_values",
+            shape=values_shape,
+            dtype=self._values_dtype,
+            initializer=tf.keras.initializers.zeros,
+        )
+        self._size = np.prod(tf.TensorShape(values_shape).as_list())
+
+    def update_state(self, values, sample_weight=None):
+        values = tf.cast(values, self._values_dtype)
+        changed_values = tf.count_nonzero(tf.equal(self._previous_values, values))
+        metric_update_op = super().update_state(changed_values / self._size)
+        with tf.control_dependencies([metric_update_op]):
+            return self._previous_values.assign(values)
+
+    def reset_states(self):
+        tf.keras.backend.batch_set_value(
+            [(v, 0) for v in self.variables if v != self._previous_values]
+        )

--- a/larq/metrics.py
+++ b/larq/metrics.py
@@ -1,5 +1,5 @@
 import tensorflow as tf
-import distutils.version as version
+from distutils.version import LooseVersion
 import numpy as np
 
 
@@ -38,7 +38,7 @@ class MeanChangedValues(tf.keras.metrics.Mean):
         initializer=None,
         dtype=None,
     ):
-        if version.LooseVersion(tf.__version__) < version.LooseVersion("1.14.0"):
+        if LooseVersion(tf.__version__) < LooseVersion("1.14.0"):
             return tf.keras.layers.Layer.add_weight(
                 self,
                 name=name,

--- a/larq/metrics.py
+++ b/larq/metrics.py
@@ -18,7 +18,7 @@ class MeanChangedValues(tf.keras.metrics.Mean):
 
     def update_state(self, values, sample_weight=None):
         values = tf.cast(values, self._values_dtype)
-        changed_values = tf.count_nonzero(tf.equal(self._previous_values, values))
+        changed_values = tf.math.count_nonzero(tf.equal(self._previous_values, values))
         metric_update_op = super().update_state(changed_values / self._size)
         with tf.control_dependencies([metric_update_op]):
             return self._previous_values.assign(values)

--- a/larq/metrics_test.py
+++ b/larq/metrics_test.py
@@ -29,21 +29,20 @@ class FlipRatioTest(keras_parameterized.TestCase):
         self.assertAllClose(0, self.evaluate(mcv.total))
         self.assertAllClose(0, self.evaluate(mcv.count))
 
-        # Ignore the first update since it is used to setup the previous_values
         self.evaluate(mcv.update_state([1, 1]))
         self.assertAllClose([1, 1], self.evaluate(mcv._previous_values))
         self.assertAllClose(0, self.evaluate(mcv.total))
-        self.assertAllClose(0, self.evaluate(mcv.count))
+        self.assertAllClose(1, self.evaluate(mcv.count))
         self.assertAllClose(0, mcv.result())
 
         self.evaluate(mcv.update_state([2, 2]))
         self.assertAllClose([2, 2], self.evaluate(mcv._previous_values))
         self.assertAllClose(1, self.evaluate(mcv.total))
-        self.assertAllClose(1, self.evaluate(mcv.count))
+        self.assertAllClose(2, self.evaluate(mcv.count))
         self.assertAllClose(1, mcv.result())
 
         self.evaluate(mcv.update_state([1, 2]))
         self.assertAllClose([1, 2], self.evaluate(mcv._previous_values))
         self.assertAllClose(1.5, self.evaluate(mcv.total))
-        self.assertAllClose(2, self.evaluate(mcv.count))
+        self.assertAllClose(3, self.evaluate(mcv.count))
         self.assertAllClose(1.5 / 2, mcv.result())

--- a/larq/metrics_test.py
+++ b/larq/metrics_test.py
@@ -1,0 +1,21 @@
+import tensorflow as tf
+from larq import metrics
+
+
+class MeanChangedValuesTest(tf.test.TestCase):
+    def test_config(self):
+        mcv = metrics.MeanChangedValues(
+            values_shape=[3, 3], values_dtype="int16", name="mcv", dtype=tf.float16
+        )
+        self.assertEqual(mcv.name, "mcv")
+        self.assertTrue(mcv.stateful)
+        self.assertEqual(mcv.dtype, tf.float16)
+        self.assertEqual(mcv.values_dtype, tf.int16)
+        self.assertEqual(mcv.values_shape, [3, 3])
+
+        mcv2 = metrics.MeanChangedValues.from_config(mcv.get_config())
+        self.assertEqual(mcv2.name, "mcv")
+        self.assertTrue(mcv2.stateful)
+        self.assertEqual(mcv2.dtype, tf.float16)
+        self.assertEqual(mcv2.values_dtype, tf.int16)
+        self.assertEqual(mcv2.values_shape, [3, 3])

--- a/larq/metrics_test.py
+++ b/larq/metrics_test.py
@@ -30,26 +30,21 @@ class MeanChangedValuesTest(tf.test.TestCase):
         self.assertAllClose(0, self.evaluate(mcv.total))
         self.assertAllClose(0, self.evaluate(mcv.count))
 
+        # Ignore the first update since it is used to setup the previous_values
         self.evaluate(mcv.update_state([1, 1]))
         self.assertAllClose([1, 1], self.evaluate(mcv._previous_values))
+        self.assertAllClose(0, self.evaluate(mcv.total))
+        self.assertAllClose(0, self.evaluate(mcv.count))
+        self.assertAllClose(0, mcv.result())
+
+        self.evaluate(mcv.update_state([2, 2]))
+        self.assertAllClose([2, 2], self.evaluate(mcv._previous_values))
         self.assertAllClose(1, self.evaluate(mcv.total))
         self.assertAllClose(1, self.evaluate(mcv.count))
         self.assertAllClose(1, mcv.result())
 
-        self.evaluate(mcv.update_state([1, 1]))
-        self.assertAllClose([1, 1], self.evaluate(mcv._previous_values))
-        self.assertAllClose(1, self.evaluate(mcv.total))
-        self.assertAllClose(2, self.evaluate(mcv.count))
-        self.assertAllClose(0.5, mcv.result())
-
-        self.evaluate(mcv.update_state([1, 1]))
-        self.assertAllClose([1, 1], self.evaluate(mcv._previous_values))
-        self.assertAllClose(1, self.evaluate(mcv.total))
-        self.assertAllClose(3, self.evaluate(mcv.count))
-        self.assertAllClose(1 / 3, mcv.result())
-
         self.evaluate(mcv.update_state([1, 2]))
         self.assertAllClose([1, 2], self.evaluate(mcv._previous_values))
         self.assertAllClose(1.5, self.evaluate(mcv.total))
-        self.assertAllClose(4, self.evaluate(mcv.count))
-        self.assertAllClose(1.5 / 4, mcv.result())
+        self.assertAllClose(2, self.evaluate(mcv.count))
+        self.assertAllClose(1.5 / 2, mcv.result())

--- a/larq/metrics_test.py
+++ b/larq/metrics_test.py
@@ -3,9 +3,9 @@ from larq import metrics
 from tensorflow.python.keras import keras_parameterized
 
 
-class MeanChangedValuesTest(keras_parameterized.TestCase):
+class FlipRatioTest(keras_parameterized.TestCase):
     def test_config(self):
-        mcv = metrics.MeanChangedValues(
+        mcv = metrics.FlipRatio(
             values_shape=[3, 3], values_dtype="int16", name="mcv", dtype=tf.float16
         )
         self.assertEqual(mcv.name, "mcv")
@@ -14,7 +14,7 @@ class MeanChangedValuesTest(keras_parameterized.TestCase):
         self.assertEqual(mcv.values_dtype, tf.int16)
         self.assertEqual(mcv.values_shape, [3, 3])
 
-        mcv2 = metrics.MeanChangedValues.from_config(mcv.get_config())
+        mcv2 = metrics.FlipRatio.from_config(mcv.get_config())
         self.assertEqual(mcv2.name, "mcv")
         self.assertTrue(mcv2.stateful)
         self.assertEqual(mcv2.dtype, tf.float16)
@@ -22,7 +22,7 @@ class MeanChangedValuesTest(keras_parameterized.TestCase):
         self.assertEqual(mcv2.values_shape, [3, 3])
 
     def test_metric(self):
-        mcv = metrics.MeanChangedValues([2])
+        mcv = metrics.FlipRatio([2])
         self.evaluate(tf.compat.v1.variables_initializer(mcv.variables))
 
         self.assertAllClose(0, mcv.result())

--- a/larq/metrics_test.py
+++ b/larq/metrics_test.py
@@ -24,7 +24,7 @@ class MeanChangedValuesTest(tf.test.TestCase):
     @test_util.run_in_graph_and_eager_modes
     def test_metric(self):
         mcv = metrics.MeanChangedValues([2])
-        self.evaluate(tf.variables_initializer(mcv.variables))
+        self.evaluate(tf.compat.v1.variables_initializer(mcv.variables))
 
         self.assertAllClose(0, mcv.result())
         self.assertAllClose(0, self.evaluate(mcv.total))

--- a/larq/metrics_test.py
+++ b/larq/metrics_test.py
@@ -1,9 +1,9 @@
 import tensorflow as tf
-from tensorflow.python.framework import test_util
 from larq import metrics
+from tensorflow.python.keras import keras_parameterized
 
 
-class MeanChangedValuesTest(tf.test.TestCase):
+class MeanChangedValuesTest(keras_parameterized.TestCase):
     def test_config(self):
         mcv = metrics.MeanChangedValues(
             values_shape=[3, 3], values_dtype="int16", name="mcv", dtype=tf.float16
@@ -21,7 +21,6 @@ class MeanChangedValuesTest(tf.test.TestCase):
         self.assertEqual(mcv2.values_dtype, tf.int16)
         self.assertEqual(mcv2.values_shape, [3, 3])
 
-    @test_util.run_in_graph_and_eager_modes
     def test_metric(self):
         mcv = metrics.MeanChangedValues([2])
         self.evaluate(tf.compat.v1.variables_initializer(mcv.variables))

--- a/larq/optimizers.py
+++ b/larq/optimizers.py
@@ -1,10 +1,7 @@
 import tensorflow as tf
-import distutils.version
+from distutils.version import LooseVersion
 
-tf_version = distutils.version.LooseVersion(tf.__version__)
-v_1_14 = distutils.version.LooseVersion("1.14.0")
-
-if tf_version >= v_1_14:
+if LooseVersion(tf.__version__) >= LooseVersion("1.14.0"):
     from larq.optimizers_v2 import Bop
 
     __all__ = ["Bop"]

--- a/larq/optimizers.py
+++ b/larq/optimizers.py
@@ -1,7 +1,6 @@
-import tensorflow as tf
-from distutils.version import LooseVersion
+from larq import utils
 
-if LooseVersion(tf.__version__) >= LooseVersion("1.14.0"):
+if utils.tf_1_14_or_newer():
     from larq.optimizers_v2 import Bop
 
     __all__ = ["Bop"]

--- a/larq/optimizers_test.py
+++ b/larq/optimizers_test.py
@@ -2,7 +2,7 @@ import pytest
 import numpy as np
 import tensorflow as tf
 import larq as lq
-import distutils.version
+from distutils.version import LooseVersion
 
 from larq import testing_utils as lq_testing_utils
 from tensorflow import keras
@@ -54,8 +54,7 @@ def _test_serialization(optimizer):
 
 
 @pytest.mark.skipif(
-    distutils.version.LooseVersion(tf.__version__)
-    >= distutils.version.LooseVersion("1.14"),
+    LooseVersion(tf.__version__) >= LooseVersion("1.14"),
     reason="current implementation requires Tensorflow 1.13 or less",
 )
 class TestXavierLearingRateScaling:

--- a/larq/optimizers_test.py
+++ b/larq/optimizers_test.py
@@ -2,9 +2,8 @@ import pytest
 import numpy as np
 import tensorflow as tf
 import larq as lq
-from distutils.version import LooseVersion
 
-from larq import testing_utils as lq_testing_utils
+from larq import utils, testing_utils as lq_testing_utils
 from tensorflow import keras
 from tensorflow.python.keras import testing_utils
 
@@ -54,7 +53,7 @@ def _test_serialization(optimizer):
 
 
 @pytest.mark.skipif(
-    LooseVersion(tf.__version__) >= LooseVersion("1.14"),
+    utils.tf_1_14_or_newer(),
     reason="current implementation requires Tensorflow 1.13 or less",
 )
 class TestXavierLearingRateScaling:

--- a/larq/optimizers_test.py
+++ b/larq/optimizers_test.py
@@ -40,7 +40,8 @@ def _test_optimizer(optimizer, target=0.75, test_kernels_are_binary=True):
     if test_kernels_are_binary:
         for layer in model.layers:
             if "quant" in layer.name:
-                assert np.all(np.isin(layer.get_weights(), [-1, 1]))
+                for weight in layer.trainable_weights:
+                    assert np.all(np.isin(tf.keras.backend.get_value(weight), [-1, 1]))
 
     assert history.history["acc"][-1] >= target
 

--- a/larq/testing_utils.py
+++ b/larq/testing_utils.py
@@ -158,9 +158,10 @@ def layer_test(
                 weighted_metrics=["acc"],
                 run_eagerly=should_run_eagerly(),
             )
+            model.train_on_batch(input_data, actual_output)
     else:
         model.compile("rmsprop", "mse", weighted_metrics=["acc"])
-    model.train_on_batch(input_data, actual_output)
+        model.train_on_batch(input_data, actual_output)
 
     # test as first layer in Sequential API
     layer_config = layer.get_config()

--- a/larq/testing_utils.py
+++ b/larq/testing_utils.py
@@ -150,12 +150,14 @@ def layer_test(
     # See b/120160788 for more details. This should be mitigated after 2.0.
     model = tf.keras.models.Model(x, layer(x))
     if _thread_local_data.run_eagerly is not None:
-        # Use tf.train.Optimizer in eager mode for legacy TensorFlow versions
-        # due to compatibility issues
-        opt = "rmsprop" if utils.tf_1_14_or_newer() else tf.train.RMSPropOptimizer(0.01)
-        model.compile(
-            opt, "mse", weighted_metrics=["acc"], run_eagerly=should_run_eagerly()
-        )
+        # TensorFlow < 1.14 + eager is broken, skip the test
+        if utils.tf_1_14_or_newer():
+            model.compile(
+                "rmsprop",
+                "mse",
+                weighted_metrics=["acc"],
+                run_eagerly=should_run_eagerly(),
+            )
     else:
         model.compile("rmsprop", "mse", weighted_metrics=["acc"])
     model.train_on_batch(input_data, actual_output)

--- a/larq/testing_utils.py
+++ b/larq/testing_utils.py
@@ -1,6 +1,7 @@
 import larq as lq
 import numpy as np
 import inspect
+from distutils.version import LooseVersion
 import tensorflow as tf
 
 # We should find a better solution without relying on private objects
@@ -149,8 +150,15 @@ def layer_test(
     # See b/120160788 for more details. This should be mitigated after 2.0.
     model = tf.keras.models.Model(x, layer(x))
     if _thread_local_data.run_eagerly is not None:
+        # Use tf.train.Optimizer in eager mode for legacy TensorFlow versions
+        # due to compatibility issues
+        optimizer = (
+            "rmsprop"
+            if LooseVersion(tf.__version__) >= LooseVersion("1.14.0")
+            else tf.train.RMSPropOptimizer(0.01)
+        )
         model.compile(
-            "rmsprop", "mse", weighted_metrics=["acc"], run_eagerly=should_run_eagerly()
+            optimizer, "mse", weighted_metrics=["acc"], run_eagerly=should_run_eagerly()
         )
     else:
         model.compile("rmsprop", "mse", weighted_metrics=["acc"])

--- a/larq/testing_utils.py
+++ b/larq/testing_utils.py
@@ -1,10 +1,14 @@
 import larq as lq
+import numpy as np
+import inspect
+import tensorflow as tf
 
-from tensorflow import keras
+# We should find a better solution without relying on private objects
+from tensorflow.python.keras.testing_utils import _thread_local_data, should_run_eagerly
 
 
 def get_small_bnn_model(input_dim, num_hidden, output_dim):
-    model = keras.models.Sequential()
+    model = tf.keras.models.Sequential()
     model.add(
         lq.layers.QuantDense(
             units=num_hidden,
@@ -15,7 +19,7 @@ def get_small_bnn_model(input_dim, num_hidden, output_dim):
             use_bias=False,
         )
     )
-    model.add(keras.layers.BatchNormalization())
+    model.add(tf.keras.layers.BatchNormalization())
     model.add(
         lq.layers.QuantDense(
             units=output_dim,
@@ -27,3 +31,164 @@ def get_small_bnn_model(input_dim, num_hidden, output_dim):
         )
     )
     return model
+
+
+# This is a fork of https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/keras/testing_utils.py#L72
+# as recommended in https://github.com/tensorflow/tensorflow/issues/28601#issuecomment-492810252
+def layer_test(
+    layer_cls,
+    kwargs=None,
+    input_shape=None,
+    input_dtype=None,
+    input_data=None,
+    expected_output=None,
+    expected_output_dtype=None,
+):
+    """Test routine for a layer with a single input and single output.
+    Arguments:
+      layer_cls: Layer class object.
+      kwargs: Optional dictionary of keyword arguments for instantiating the
+        layer.
+      input_shape: Input shape tuple.
+      input_dtype: Data type of the input data.
+      input_data: Numpy array of input data.
+      expected_output: Shape tuple for the expected shape of the output.
+      expected_output_dtype: Data type expected for the output.
+    Returns:
+      The output data (Numpy array) returned by the layer, for additional
+      checks to be done by the calling code.
+    Raises:
+      ValueError: if `input_shape is None`.
+    """
+    if input_data is None:
+        if input_shape is None:
+            raise ValueError("input_shape is None")
+        if not input_dtype:
+            input_dtype = "float32"
+        input_data_shape = list(input_shape)
+        for i, e in enumerate(input_data_shape):
+            if e is None:
+                input_data_shape[i] = np.random.randint(1, 4)
+        input_data = 10 * np.random.random(input_data_shape)
+        if input_dtype[:5] == "float":
+            input_data -= 0.5
+        input_data = input_data.astype(input_dtype)
+    elif input_shape is None:
+        input_shape = input_data.shape
+    if input_dtype is None:
+        input_dtype = input_data.dtype
+    if expected_output_dtype is None:
+        expected_output_dtype = input_dtype
+
+    # instantiation
+    kwargs = kwargs or {}
+    layer = layer_cls(**kwargs)
+
+    # test get_weights , set_weights at layer level
+    weights = layer.get_weights()
+    layer.set_weights(weights)
+
+    # test and instantiation from weights
+    if "weights" in inspect.getargspec(layer_cls.__init__):
+        kwargs["weights"] = weights
+        layer = layer_cls(**kwargs)
+
+    # test in functional API
+    x = tf.keras.layers.Input(shape=input_shape[1:], dtype=input_dtype)
+    y = layer(x)
+    if tf.keras.backend.dtype(y) != expected_output_dtype:
+        raise AssertionError(
+            "When testing layer %s, for input %s, found output "
+            "dtype=%s but expected to find %s.\nFull kwargs: %s"
+            % (
+                layer_cls.__name__,
+                x,
+                tf.keras.backend.dtype(y),
+                expected_output_dtype,
+                kwargs,
+            )
+        )
+    # check shape inference
+    model = tf.keras.models.Model(x, y)
+    expected_output_shape = tuple(
+        layer.compute_output_shape(tf.TensorShape(input_shape)).as_list()
+    )
+    actual_output = model.predict(input_data)
+    actual_output_shape = actual_output.shape
+    for expected_dim, actual_dim in zip(expected_output_shape, actual_output_shape):
+        if expected_dim is not None:
+            if expected_dim != actual_dim:
+                raise AssertionError(
+                    "When testing layer %s, for input %s, found output_shape="
+                    "%s but expected to find %s.\nFull kwargs: %s"
+                    % (
+                        layer_cls.__name__,
+                        x,
+                        actual_output_shape,
+                        expected_output_shape,
+                        kwargs,
+                    )
+                )
+    if expected_output is not None:
+        np.testing.assert_allclose(actual_output, expected_output, rtol=1e-3)
+
+    # test serialization, weight setting at model level
+    model_config = model.get_config()
+    recovered_model = tf.keras.models.Model.from_config(model_config)
+    if model.weights:
+        weights = model.get_weights()
+        recovered_model.set_weights(weights)
+        output = recovered_model.predict(input_data)
+        np.testing.assert_allclose(output, actual_output, rtol=2e-3)
+
+    # test training mode (e.g. useful for dropout tests)
+    # Rebuild the model to avoid the graph being reused between predict() and
+    # train(). This was causing some error for layer with Defun as it body.
+    # See b/120160788 for more details. This should be mitigated after 2.0.
+    model = tf.keras.models.Model(x, layer(x))
+    if _thread_local_data.run_eagerly is not None:
+        model.compile(
+            "rmsprop", "mse", weighted_metrics=["acc"], run_eagerly=should_run_eagerly()
+        )
+    else:
+        model.compile("rmsprop", "mse", weighted_metrics=["acc"])
+    model.train_on_batch(input_data, actual_output)
+
+    # test as first layer in Sequential API
+    layer_config = layer.get_config()
+    layer_config["batch_input_shape"] = input_shape
+    layer = layer.__class__.from_config(layer_config)
+
+    model = tf.keras.models.Sequential()
+    model.add(layer)
+    actual_output = model.predict(input_data)
+    actual_output_shape = actual_output.shape
+    for expected_dim, actual_dim in zip(expected_output_shape, actual_output_shape):
+        if expected_dim is not None:
+            if expected_dim != actual_dim:
+                raise AssertionError(
+                    "When testing layer %s **after deserialization**, "
+                    "for input %s, found output_shape="
+                    "%s but expected to find inferred shape %s.\nFull kwargs: %s"
+                    % (
+                        layer_cls.__name__,
+                        x,
+                        actual_output_shape,
+                        expected_output_shape,
+                        kwargs,
+                    )
+                )
+    if expected_output is not None:
+        np.testing.assert_allclose(actual_output, expected_output, rtol=1e-3)
+
+    # test serialization, weight setting at model level
+    model_config = model.get_config()
+    recovered_model = tf.keras.models.Sequential.from_config(model_config)
+    if model.weights:
+        weights = model.get_weights()
+        recovered_model.set_weights(weights)
+        output = recovered_model.predict(input_data)
+        np.testing.assert_allclose(output, actual_output, rtol=2e-3)
+
+    # for further checks in the caller function
+    return actual_output

--- a/larq/testing_utils.py
+++ b/larq/testing_utils.py
@@ -141,6 +141,8 @@ def layer_test(
         output = recovered_model.predict(input_data)
         np.testing.assert_allclose(output, actual_output, rtol=2e-3)
 
+    # Recreate layer to prevent layer metrics from being configured multiple times.
+    layer = layer_cls(**kwargs)
     # test training mode (e.g. useful for dropout tests)
     # Rebuild the model to avoid the graph being reused between predict() and
     # train(). This was causing some error for layer with Defun as it body.

--- a/larq/testing_utils.py
+++ b/larq/testing_utils.py
@@ -1,8 +1,8 @@
 import larq as lq
 import numpy as np
 import inspect
-from distutils.version import LooseVersion
 import tensorflow as tf
+from larq import utils
 
 # We should find a better solution without relying on private objects
 from tensorflow.python.keras.testing_utils import _thread_local_data, should_run_eagerly
@@ -152,13 +152,9 @@ def layer_test(
     if _thread_local_data.run_eagerly is not None:
         # Use tf.train.Optimizer in eager mode for legacy TensorFlow versions
         # due to compatibility issues
-        optimizer = (
-            "rmsprop"
-            if LooseVersion(tf.__version__) >= LooseVersion("1.14.0")
-            else tf.train.RMSPropOptimizer(0.01)
-        )
+        opt = "rmsprop" if utils.tf_1_14_or_newer() else tf.train.RMSPropOptimizer(0.01)
         model.compile(
-            optimizer, "mse", weighted_metrics=["acc"], run_eagerly=should_run_eagerly()
+            opt, "mse", weighted_metrics=["acc"], run_eagerly=should_run_eagerly()
         )
     else:
         model.compile("rmsprop", "mse", weighted_metrics=["acc"])

--- a/larq/utils.py
+++ b/larq/utils.py
@@ -1,3 +1,5 @@
+from distutils.version import LooseVersion
+import tensorflow as tf
 from tensorflow.keras.utils import get_custom_objects
 
 
@@ -5,3 +7,7 @@ def register_keras_custom_object(cls):
     """See https://github.com/tensorflow/addons/blob/master/tensorflow_addons/utils/keras_utils.py#L25"""
     get_custom_objects()[cls.__name__] = cls
     return cls
+
+
+def tf_1_14_or_newer():
+    return LooseVersion(tf.__version__) >= LooseVersion("1.14.0")


### PR DESCRIPTION
This is an early prototype to explore the Keras `layers.add_metrics` API for our stateful metrics as a replacements for the `QuantizedLogger`. I think this approach is a lot more flexible and elegant than using a callback.

Before I'll clean this PR up, we should check if this approach has a big performance impact since it needs to keep track of the previous quantized weights.