### PR TITLE
Improve styling of model summary

### DIFF
--- a/larq/models.py
+++ b/larq/models.py
@@ -71,7 +71,7 @@ def summary(model, line_length=None, positions=None, print_fn=None):
     line_length: Total length of printed lines
         (e.g. set this to adapt the display to different terminal window sizes).
     positions: Relative or absolute positions of log elements in each line.
-        If not provided, defaults to `[.33, .55, .67, 1.]`.
+        If not provided, defaults to `[0.38, 0.62, 0.74, 0.88, 1.0]`.
     print_fn: Print function to use. Defaults to `print`. You can set it to a custom
         function in order to capture the string summary.
 
@@ -99,18 +99,22 @@ def summary(model, line_length=None, positions=None, print_fn=None):
         print_fn = print
 
     line_length = line_length or 88
-    positions = positions or [0.36, 0.63, 0.75, 0.89, 1.0]
+    positions = positions or [0.38, 0.62, 0.74, 0.88, 1.0]
     if positions[-1] <= 1:
         positions = [int(line_length * p) for p in positions]
 
     def print_row(fields, positions):
         line = ""
         for i, (field, position) in enumerate(zip(fields, positions)):
-            if i > 0:
-                line = line[:-1] + " "
-            line += f"{field:.2f}" if type(field) == float else str(field)
-            line = line[:position]
-            line += " " * (position - len(line))
+            field = f"{field:.2f}" if type(field) == float else str(field)
+            if i == 0:
+                line += field
+                line += " " * (position - len(line))
+                line = line[: position - 1] + " "
+            else:
+                line += " " * (position - len(line) - len(field)) + field
+                line = line[:position]
+
         print_fn(line)
 
     print_fn(_get_delimiter("thick") * line_length)

--- a/larq/models.py
+++ b/larq/models.py
@@ -41,10 +41,8 @@ def _count_fp_weights(layer):
     return layer.count_params()
 
 
-def _bit_to_MB(bit_value):
-    bit_to_byte_ratio = 1.0 / 8.0
-    byte_to_mega_bytes_ratio = 1.0 / (1024 ** 2)
-    return bit_value * bit_to_byte_ratio * byte_to_mega_bytes_ratio
+def _bit_to_kB(bit_value):
+    return bit_value / 8 / 1024
 
 
 def _memory_weights(layer):
@@ -52,7 +50,7 @@ def _memory_weights(layer):
     num_binarized_params = _count_binarized_weights(layer)
     fp32 = 32  # Multiply float32 params by 32 to get bit value
     total_layer_mem_in_bits = (num_fp_params * fp32) + (num_binarized_params)
-    return _bit_to_MB(total_layer_mem_in_bits)
+    return _bit_to_kB(total_layer_mem_in_bits)
 
 
 def summary(model, tablefmt="simple", print_fn=None):
@@ -78,7 +76,7 @@ def summary(model, tablefmt="simple", print_fn=None):
             "`input_shape` argument in the first layer(s) for automatic build."
         )
 
-    header = ("Layer", "Outputs", "# 1-bit", "# 32-bit", "Memory (MB)")
+    header = ("Layer", "Outputs", "# 1-bit", "# 32-bit", "Memory (kB)")
     table = [
         [
             layer.name,
@@ -106,15 +104,15 @@ def summary(model, tablefmt="simple", print_fn=None):
     if print_fn is None:
         print_fn = print
 
-    print_fn(tabulate(table, headers=header, tablefmt=tablefmt))
+    print_fn(tabulate(table, headers=header, tablefmt=tablefmt, floatfmt=".2f"))
     print_fn()
     print_fn(f"Total params: {trainable_count + non_trainable_count}")
     print_fn(f"Trainable params: {trainable_count}")
     print_fn(f"Non-trainable params: {non_trainable_count}")
 
-    float32_equiv = _bit_to_MB((amount_binarized + amount_full_precision) * 32)
+    float32_equiv = _bit_to_kB((amount_binarized + amount_full_precision) * 32)
     compression_ratio = float32_equiv / total_memory
 
-    print_fn(f"Float-32 Equivalent: {float32_equiv:.2f} MB")
+    print_fn(f"Float-32 Equivalent: {float32_equiv:.2f} kB")
     print_fn(f"Compression of Memory: {compression_ratio:.2f}")
     print_fn()

--- a/larq/models.py
+++ b/larq/models.py
@@ -145,6 +145,6 @@ def summary(model, line_length=None, positions=None, print_fn=None):
     compression_ratio = float32_equiv / total_memory
 
     print_fn(_get_delimiter() * line_length)
-    print_fn(f"Float-32 Equivalent: {float32_equiv:.2f} kB")
+    print_fn(f"Float-32 Equivalent: {float32_equiv / 1024:.2f} MB")
     print_fn(f"Compression of Memory: {compression_ratio:.2f}")
     print_fn(_get_delimiter("thick") * line_length)

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     url="https://larq.dev/",
     packages=find_packages(),
     license="Apache 2.0",
-    install_requires=["numpy >= 1.15.4, < 2.0", "tabulate >= 0.8.3"],
+    install_requires=["numpy >= 1.15.4, < 2.0"],
     extras_require={
         "tensorflow": ["tensorflow>=1.13.1"],
         "tensorflow_gpu": ["tensorflow-gpu>=1.13.1"],


### PR DESCRIPTION
This OR includes a bunch of changes to the model summary for better readability:
- Convert MB to kB since layer sizes can be quite small
- Switch from `tabulate` to custom printing to have more flexibility and to fix appearance in terminals that don't properly support unicode (like some of our docker containers we run in the cloud).
- Pretty print horizontal lines on terminals that support Unicode
- Make table width configurable with the same API as Keras
```
========================================================================================
Layer                                          Outputs    # 1-bit    # 32-bit   Mem (kB)
----------------------------------------------------------------------------------------
quant_conv2d                          (-1, 30, 30, 64)       1728           0       0.21
batch_normalization                   (-1, 30, 30, 64)          0         192       0.75
quant_conv2d_1                        (-1, 30, 30, 64)      36864           0       4.50
max_pooling2d                         (-1, 15, 15, 64)          0           0       0.00
batch_normalization_1                 (-1, 15, 15, 64)          0         192       0.75
quant_conv2d_2                       (-1, 15, 15, 128)      73728           0       9.00
batch_normalization_2                (-1, 15, 15, 128)          0         384       1.50
quant_conv2d_3                       (-1, 15, 15, 128)     147456           0      18.00
max_pooling2d_1                        (-1, 7, 7, 128)          0           0       0.00
batch_normalization_3                  (-1, 7, 7, 128)          0         384       1.50
quant_conv2d_4                         (-1, 7, 7, 256)     294912           0      36.00
batch_normalization_4                  (-1, 7, 7, 256)          0         768       3.00
quant_conv2d_5                         (-1, 7, 7, 256)     589824           0      72.00
max_pooling2d_2                        (-1, 3, 3, 256)          0           0       0.00
batch_normalization_5                  (-1, 3, 3, 256)          0         768       3.00
flatten                                     (-1, 2304)          0           0       0.00
quant_dense                                 (-1, 4096)    9437184           0    1152.00
batch_normalization_6                       (-1, 4096)          0       12288      48.00
quant_dense_1                               (-1, 4096)   16777216           0    2048.00
batch_normalization_7                       (-1, 4096)          0       12288      48.00
quant_dense_2                                 (-1, 10)      40960           0       5.00
batch_normalization_8                         (-1, 10)          0          30       0.12
activation                                    (-1, 10)          0           0       0.00
----------------------------------------------------------------------------------------
Total                                                    27399872       27294    3451.33
========================================================================================
Total params: 27427166
Trainable params: 27408970
Non-trainable params: 18196
----------------------------------------------------------------------------------------
Float-32 Equivalent: 104.63 MB
Compression of Memory: 31.04
========================================================================================
```