### PR TITLE
Switch to terminaltables for generating our summary

### DIFF
--- a/larq/models.py
+++ b/larq/models.py
@@ -110,6 +110,6 @@ def summary(model, tablefmt="simple", print_fn=None):
     float32_equiv = _bit_to_kB((amount_binarized + amount_full_precision) * 32)
     compression_ratio = float32_equiv / total_memory
 
-    print_fn(f"Float-32 Equivalent: {float32_equiv:.2f} kB")
+    print_fn(f"Float-32 Equivalent: {float32_equiv / 1024:.2f} MB")
     print_fn(f"Compression of Memory: {compression_ratio:.2f}")
     print_fn()

--- a/larq/models.py
+++ b/larq/models.py
@@ -7,7 +7,9 @@ def sanitize_table(table_data):
 
 
 class LayersTable(AsciiTable):
-    def __init__(self, table_data, title=None):
+    def __init__(self, table_data, title=None, header=None):
+        if header:
+            table_data.insert(0, header)
         super().__init__(table_data, title=title)
         self.inner_column_border = False
         self.justify_columns = {
@@ -107,7 +109,6 @@ def summary(model, tablefmt="simple", print_fn=None):
     amount_binarized = sum(r[2] for r in table)
     amount_full_precision = sum(r[3] for r in table)
     total_memory = sum(r[4] for r in table)
-    table.insert(0, ["Layer", "Outputs", "# 1-bit", "# 32-bit", "Memory (kB)"])
     table.append(["Total", "", amount_binarized, amount_full_precision, total_memory])
 
     model._check_trainable_weights_consistency()
@@ -135,7 +136,13 @@ def summary(model, tablefmt="simple", print_fn=None):
         ["Compression of Memory", compression_ratio],
     ]
 
-    print_fn(LayersTable(sanitize_table(table), title=f"{model.name} stats").table)
+    print_fn(
+        LayersTable(
+            sanitize_table(table),
+            title=f"{model.name} stats",
+            header=["Layer", "Outputs", "# 1-bit", "# 32-bit", "Memory (kB)"],
+        ).table
+    )
     print_fn(
         SummaryTable(sanitize_table(summary_table), title=f"{model.name} summary").table
     )

--- a/larq/models.py
+++ b/larq/models.py
@@ -2,6 +2,10 @@ import numpy as np
 from terminaltables import AsciiTable
 
 
+def sanitize_table(table_data):
+    return [[f"{v:.2f}" if type(v) == float else v for v in row] for row in table_data]
+
+
 class LayersTable(AsciiTable):
     def __init__(self, table_data, title=None):
         super().__init__(table_data, title=title)
@@ -128,6 +132,8 @@ def summary(model, tablefmt="simple", print_fn=None):
         ["Compression of Memory", compression_ratio],
     ]
 
-    print_fn(LayersTable(table, title=f"{model.name} stats").table)
-    print_fn(SummaryTable(summary_table, title=f"{model.name} summary").table)
+    print_fn(LayersTable(sanitize_table(table), title=f"{model.name} stats").table)
+    print_fn(
+        SummaryTable(sanitize_table(summary_table), title=f"{model.name} summary").table
+    )
     print_fn()

--- a/larq/models.py
+++ b/larq/models.py
@@ -10,6 +10,9 @@ class LayersTable(AsciiTable):
     def __init__(self, table_data, title=None):
         super().__init__(table_data, title=title)
         self.inner_column_border = False
+        self.justify_columns = {
+            i: "left" if i == 0 else "right" for i in range(len(table_data[0]))
+        }
         self.inner_footing_row_border = True
         self.inner_heading_row_border = True
 

--- a/larq/models.py
+++ b/larq/models.py
@@ -1,15 +1,5 @@
-from sys import stdout
 import numpy as np
-
-
-def _terminal_supports_unicode():
-    return hasattr(stdout, "encoding") and stdout.encoding in ("utf-8", "UTF-8", "UTF8")
-
-
-def _get_delimiter(type_="thin"):
-    if _terminal_supports_unicode():
-        return "━" if type_ == "thick" else "─"
-    return "=" if type_ == "thick" else "-"
+from tabulate import tabulate
 
 
 def _count_params(weights, ignore=[]):
@@ -45,8 +35,10 @@ def _count_fp_weights(layer, ignore=[]):
     return _count_params(layer.weights, ignored_weights)
 
 
-def _bit_to_kB(bit_value):
-    return bit_value / 8 / 1024
+def _bit_to_MB(bit_value):
+    bit_to_byte_ratio = 1.0 / 8.0
+    byte_to_mega_bytes_ratio = 1.0 / (1024 ** 2)
+    return bit_value * bit_to_byte_ratio * byte_to_mega_bytes_ratio
 
 
 def _memory_weights(layer, ignore=[]):
@@ -54,18 +46,18 @@ def _memory_weights(layer, ignore=[]):
     num_binarized_params = _count_binarized_weights(layer)
     fp32 = 32  # Multiply float32 params by 32 to get bit value
     total_layer_mem_in_bits = (num_fp_params * fp32) + (num_binarized_params)
-    return _bit_to_kB(total_layer_mem_in_bits)
+    return _bit_to_MB(total_layer_mem_in_bits)
 
 
-def summary(model, line_length=None, positions=None, print_fn=None):
+def summary(model, tablefmt="simple", print_fn=None):
     """Prints a string summary of the network.
 
     # Arguments
     model: `tf.keras` model instance.
-    line_length: Total length of printed lines
-        (e.g. set this to adapt the display to different terminal window sizes).
-    positions: Relative or absolute positions of log elements in each line.
-        If not provided, defaults to `[0.38, 0.62, 0.74, 0.88, 1.0]`.
+    tablefmt: Supported table formats are: `fancy_grid`, `github`, `grid`, `html`,
+        `jira`, `latex`, `latex_booktabs`, `latex_raw`, `mediawiki`, `moinmoin`,
+        `orgtbl`, `pipe`, `plain`, `presto`, `psql`, `rst`, `simple`, `textile`,
+        `tsv`, `youtrac`.
     print_fn: Print function to use. Defaults to `print`. You can set it to a custom
         function in order to capture the string summary.
 
@@ -80,8 +72,24 @@ def summary(model, line_length=None, positions=None, print_fn=None):
             "`input_shape` argument in the first layer(s) for automatic build."
         )
 
-    header = ("Layer", "Outputs", "# 1-bit", "# 32-bit", "Mem (kB)")
+    header = ("Layer", "Outputs", "# 1-bit", "# 32-bit", "Memory (MB)")
     metrics_weights = [weight for metric in model.metrics for weight in metric.weights]
+    table = [
+        [
+            layer.name,
+            _get_output_shape(layer),
+            _count_binarized_weights(layer),
+            _count_fp_weights(layer),
+            _memory_weights(layer),
+        ]
+        for layer in model.layers
+    ]
+
+    amount_binarized = sum(r[2] for r in table)
+    amount_full_precision = sum(r[3] for r in table)
+    total_memory = sum(r[4] for r in table)
+
+    table.append(["Total", None, amount_binarized, amount_full_precision, total_memory])
 
     model._check_trainable_weights_consistency()
     if hasattr(model, "_collected_trainable_weights"):
@@ -95,53 +103,15 @@ def summary(model, line_length=None, positions=None, print_fn=None):
     if print_fn is None:
         print_fn = print
 
-    line_length = line_length or 88
-    positions = positions or [0.38, 0.62, 0.74, 0.88, 1.0]
-    if positions[-1] <= 1:
-        positions = [int(line_length * p) for p in positions]
-
-    def print_row(fields, positions):
-        line = ""
-        for i, (field, position) in enumerate(zip(fields, positions)):
-            field = f"{field:.2f}" if type(field) == float else str(field)
-            if i == 0:
-                line += field
-                line += " " * (position - len(line))
-                line = line[: position - 1] + " "
-            else:
-                line += " " * (position - len(line) - len(field)) + field
-                line = line[:position]
-
-        print_fn(line)
-
-    print_fn(_get_delimiter("thick") * line_length)
-    print_row(header, positions)
-    print_fn(_get_delimiter() * line_length)
-
-    amount_binarized = amount_full_precision = total_memory = 0
-    for layer in model.layers:
-        n_bin = _count_binarized_weights(layer)
-        n_fp = _count_fp_weights(layer, ignore=metrics_weights)
-        memory = _memory_weights(layer, ignore=metrics_weights)
-        amount_binarized += n_bin
-        amount_full_precision += n_fp
-        total_memory += memory
-        print_row(
-            (layer.name, _get_output_shape(layer), n_bin, n_fp, memory), positions
-        )
-    print_fn(_get_delimiter() * line_length)
-    print_row(
-        ("Total", "", amount_binarized, amount_full_precision, total_memory), positions
-    )
-    print_fn(_get_delimiter("thick") * line_length)
+    print_fn(tabulate(table, headers=header, tablefmt=tablefmt))
+    print_fn()
     print_fn(f"Total params: {trainable_count + non_trainable_count}")
     print_fn(f"Trainable params: {trainable_count}")
     print_fn(f"Non-trainable params: {non_trainable_count}")
 
-    float32_equiv = _bit_to_kB((amount_binarized + amount_full_precision) * 32)
+    float32_equiv = _bit_to_MB((amount_binarized + amount_full_precision) * 32)
     compression_ratio = float32_equiv / total_memory
 
-    print_fn(_get_delimiter() * line_length)
-    print_fn(f"Float-32 Equivalent: {float32_equiv / 1024:.2f} MB")
+    print_fn(f"Float-32 Equivalent: {float32_equiv:.2f} MB")
     print_fn(f"Compression of Memory: {compression_ratio:.2f}")
-    print_fn(_get_delimiter("thick") * line_length)
+    print_fn()

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     url="https://larq.dev/",
     packages=find_packages(),
     license="Apache 2.0",
-    install_requires=["numpy >= 1.15.4, < 2.0", "tabulate >= 0.8.3"],
+    install_requires=["numpy >= 1.15.4, < 2.0", "terminaltables>=3.1.0"],
     extras_require={
         "tensorflow": ["tensorflow>=1.13.1"],
         "tensorflow_gpu": ["tensorflow-gpu>=1.13.1"],

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     url="https://larq.dev/",
     packages=find_packages(),
     license="Apache 2.0",
-    install_requires=["numpy >= 1.15.4, < 2.0"],
+    install_requires=["numpy >= 1.15.4, < 2.0", "tabulate >= 0.8.3"],
     extras_require={
         "tensorflow": ["tensorflow>=1.13.1"],
         "tensorflow_gpu": ["tensorflow-gpu>=1.13.1"],


### PR DESCRIPTION
This largely reverts #121 and refactors `model.summary()` to use `terminaltabs` for better maintainability in preparation for #91

Here is a example output:
```
+sequential stats-----------------------------------------------------------+
| Layer                            Outputs   # 1-bit  # 32-bit  Memory (kB) |
+---------------------------------------------------------------------------+
| quant_conv2d            (-1, 30, 30, 64)      1728         0         0.21 |
| batch_normalization     (-1, 30, 30, 64)         0       192         0.75 |
| quant_conv2d_1          (-1, 30, 30, 64)     36864         0         4.50 |
| max_pooling2d           (-1, 15, 15, 64)         0         0         0.00 |
| batch_normalization_1   (-1, 15, 15, 64)         0       192         0.75 |
| quant_conv2d_2         (-1, 15, 15, 128)     73728         0         9.00 |
| batch_normalization_2  (-1, 15, 15, 128)         0       384         1.50 |
| quant_conv2d_3         (-1, 15, 15, 128)    147456         0        18.00 |
| max_pooling2d_1          (-1, 7, 7, 128)         0         0         0.00 |
| batch_normalization_3    (-1, 7, 7, 128)         0       384         1.50 |
| quant_conv2d_4           (-1, 7, 7, 256)    294912         0        36.00 |
| batch_normalization_4    (-1, 7, 7, 256)         0       768         3.00 |
| quant_conv2d_5           (-1, 7, 7, 256)    589824         0        72.00 |
| max_pooling2d_2          (-1, 3, 3, 256)         0         0         0.00 |
| batch_normalization_5    (-1, 3, 3, 256)         0       768         3.00 |
| flatten                       (-1, 2304)         0         0         0.00 |
| quant_dense                   (-1, 4096)   9437184         0      1152.00 |
| batch_normalization_6         (-1, 4096)         0     12288        48.00 |
| quant_dense_1                 (-1, 4096)  16777216         0      2048.00 |
| batch_normalization_7         (-1, 4096)         0     12288        48.00 |
| quant_dense_2                   (-1, 10)     40960         0         5.00 |
| batch_normalization_8           (-1, 10)         0        30         0.12 |
| activation                      (-1, 10)         0         0         0.00 |
+---------------------------------------------------------------------------+
| Total                                     27399872     27294      3451.33 |
+---------------------------------------------------------------------------+
+sequential summary----------------+
| Total params           27427166  |
| Trainable params       27408970  |
| Non-trainable params   18196     |
| Float-32 Equivalent    104.63 MB |
| Compression of Memory  31.04     |
+----------------------------------+
```