### PR TITLE
Ignore weights from layer metrics in summary

### DIFF
--- a/larq/models.py
+++ b/larq/models.py
@@ -81,12 +81,7 @@ def summary(model, line_length=None, positions=None, print_fn=None):
         )
 
     header = ("Layer", "Outputs", "# 1-bit", "# 32-bit", "Mem (kB)")
-    metrics_weights = [
-        weight
-        for layer in model.layers
-        for metric in layer.metrics
-        for weight in metric.weights
-    ]
+    metrics_weights = [weight for metric in model.metrics for weight in metric.weights]
 
     model._check_trainable_weights_consistency()
     if hasattr(model, "_collected_trainable_weights"):


### PR DESCRIPTION
#100 introduced non-trainable weights that will mess up the `model.summary()`. With this PR the model summary will ignore all parameters that are related to metrics. @jamescook106 Thanks for catching this.