### PR TITLE
Fix Binder links for example notebooks

### DIFF
--- a/docs/examples/binarynet_advanced_cifar10.ipynb
+++ b/docs/examples/binarynet_advanced_cifar10.ipynb
@@ -5,7 +5,7 @@
       "source": [
         "# BinaryNet on CIFAR10 (Advanced)\n",
         "\n",
-        "**Run this notebook here: [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/plumerai/larq/master?filepath=examples%2Fbinarynet_advanced_cifar10.ipynb)**\n",
+        "**Run this notebook here: [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/plumerai/larq/master?filepath=docs%2Fexamples%2Fbinarynet_advanced_cifar10.ipynb)**\n",
         "\n",
         "In this example we demonstrate how to use Larq to build and train BinaryNet on the CIFAR10 dataset to achieve a validation accuracy of around 90% using a heavy lifting GPU like a Nvidia V100.\n",
         "On a Nvidia V100 it takes approximately 250 minutes to train. Compared to the original papers, [BinaryConnect: Training Deep Neural Networks with binary weights during propagations](https://arxiv.org/abs/1511.00363), and [Binarized Neural Networks: Training Deep Neural Networks with Weights and Activations Constrained to +1 or -1](http://arxiv.org/abs/1602.02830), we do not implement image whitening, but we use image augmentation, and a stepped learning rate scheduler."

--- a/docs/examples/binarynet_cifar10.ipynb
+++ b/docs/examples/binarynet_cifar10.ipynb
@@ -5,7 +5,7 @@
       "source": [
         "# BinaryNet on CIFAR10\n",
         "\n",
-        "**Run this notebook here: [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/plumerai/larq/master?filepath=examples%2Fbinarynet_cifar10.ipynb)**\n",
+        "**Run this notebook here: [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/plumerai/larq/master?filepath=docs%2Fexamples%2Fbinarynet_cifar10.ipynb)**\n",
         "\n",
         "In this example we demonstrate how to use Larq to build and train BinaryNet on the CIFAR10 dataset to achieve a validation accuracy approximately 83% on laptop hardware.\n",
         "On a Nvidia GTX 1050 Ti Max-Q it takes approximately 200 minutes to train. For simplicity, compared to the original papers [BinaryConnect: Training Deep Neural Networks with binary weights during propagations](https://arxiv.org/abs/1511.00363), and [Binarized Neural Networks: Training Deep Neural Networks with Weights and Activations Constrained to +1 or -1](http://arxiv.org/abs/1602.02830), we do not impliment learning rate scaling, or image whitening."

--- a/docs/examples/mnist.ipynb
+++ b/docs/examples/mnist.ipynb
@@ -5,7 +5,7 @@
       "source": [
         "# Introduction to BNNs with Larq\n",
         "\n",
-        "**Run this notebook here: [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/plumerai/larq/master?filepath=examples%2Fmnist.ipynb)**\n",
+        "**Run this notebook here: [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/plumerai/larq/master?filepath=docs%2Fexamples%2Fmnist.ipynb)**\n",
         "\n",
         "This tutorial demonstrates how to train a simple binarized Convolutional Neural Network (CNN) to classify MNIST digits. This simple network will achieve approximately 98% accuracy on the MNIST test set. This tutorial uses Larq and the [Keras Sequential API](https://www.tensorflow.org/guide/keras), so creating and training our model will require only a few lines of code."
       ],


### PR DESCRIPTION
Looks like these example notebooks moved from `examples` to `docs/examples` at some point, which broke the *launch binder* badges at the top of the notebooks.

Prepending `docs%2F` to the `filepath` URL parameter fixes the links for me.

(Edited on GitHub's web editor, which automatically added a newline at the end of each notebook I touched.)