### PR TITLE
Add links to notebooks on GitHub and improve buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Azure DevOps builds](https://img.shields.io/azure-devops/build/plumerai/larq/5.svg?logo=azure-devops)](https://plumerai.visualstudio.com/larq/_build/latest?definitionId=5&branchName=master) [![Azure DevOps coverage](https://img.shields.io/azure-devops/coverage/plumerai/larq/5.svg?logo=azure-devops)](https://plumerai.visualstudio.com/larq/_build/latest?definitionId=5&branchName=master) [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/larq.svg)](https://pypi.org/project/larq/) [![PyPI](https://img.shields.io/pypi/v/larq.svg)](https://pypi.org/project/larq/) [![PyPI - License](https://img.shields.io/pypi/l/larq.svg)](https://github.com/plumerai/larq/blob/master/LICENSE) [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/ambv/black)
 
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/plumerai/larq/master?filepath=examples) [![Join the community on Spectrum](https://withspectrum.github.io/badge/badge.svg)](https://spectrum.chat/larq)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/plumerai/larq/master?filepath=docs%2Fexamples) [![Join the community on Spectrum](https://withspectrum.github.io/badge/badge.svg)](https://spectrum.chat/larq)
 
 Larq is an open-source deep learning library for training neural networks with extremely low precision weights and activations, such as Binarized Neural Networks (BNNs).
 

--- a/docs/examples/binarynet_advanced_cifar10.ipynb
+++ b/docs/examples/binarynet_advanced_cifar10.ipynb
@@ -5,7 +5,7 @@
       "source": [
         "# BinaryNet on CIFAR10 (Advanced)\n",
         "\n",
-        "**Run this notebook here: [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/plumerai/larq/master?filepath=docs%2Fexamples%2Fbinarynet_advanced_cifar10.ipynb)**\n",
+        "<a href=\"https://mybinder.org/v2/gh/plumerai/larq/master?filepath=docs%2Fexamples%2Fbinarynet_advanced_cifar10.ipynb\"><button data-md-color-primary=\"blue\">Run on Binder</button></a> <a href=\"https://github.com/plumerai/larq/blob/master/docs/examples/binarynet_advanced_cifar10.ipynb\"><button data-md-color-primary=\"blue\">View on GitHub</button></a>\n",
         "\n",
         "In this example we demonstrate how to use Larq to build and train BinaryNet on the CIFAR10 dataset to achieve a validation accuracy of around 90% using a heavy lifting GPU like a Nvidia V100.\n",
         "On a Nvidia V100 it takes approximately 250 minutes to train. Compared to the original papers, [BinaryConnect: Training Deep Neural Networks with binary weights during propagations](https://arxiv.org/abs/1511.00363), and [Binarized Neural Networks: Training Deep Neural Networks with Weights and Activations Constrained to +1 or -1](http://arxiv.org/abs/1602.02830), we do not implement image whitening, but we use image augmentation, and a stepped learning rate scheduler."
@@ -281,7 +281,7 @@
       "file_extension": ".py"
     },
     "nteract": {
-      "version": "0.13.0"
+      "version": "0.14.3"
     }
   },
   "nbformat": 4,

--- a/docs/examples/binarynet_cifar10.ipynb
+++ b/docs/examples/binarynet_cifar10.ipynb
@@ -5,7 +5,7 @@
       "source": [
         "# BinaryNet on CIFAR10\n",
         "\n",
-        "**Run this notebook here: [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/plumerai/larq/master?filepath=docs%2Fexamples%2Fbinarynet_cifar10.ipynb)**\n",
+        "<a href=\"https://mybinder.org/v2/gh/plumerai/larq/master?filepath=docs%2Fexamples%2Fbinarynet_cifar10.ipynb\"><button data-md-color-primary=\"blue\">Run on Binder</button></a> <a href=\"https://github.com/plumerai/larq/blob/master/docs/examples/binarynet_cifar10.ipynb\"><button data-md-color-primary=\"blue\">View on GitHub</button></a>\n",
         "\n",
         "In this example we demonstrate how to use Larq to build and train BinaryNet on the CIFAR10 dataset to achieve a validation accuracy approximately 83% on laptop hardware.\n",
         "On a Nvidia GTX 1050 Ti Max-Q it takes approximately 200 minutes to train. For simplicity, compared to the original papers [BinaryConnect: Training Deep Neural Networks with binary weights during propagations](https://arxiv.org/abs/1511.00363), and [Binarized Neural Networks: Training Deep Neural Networks with Weights and Activations Constrained to +1 or -1](http://arxiv.org/abs/1602.02830), we do not impliment learning rate scaling, or image whitening."
@@ -530,7 +530,7 @@
       "file_extension": ".py"
     },
     "nteract": {
-      "version": "0.13.0"
+      "version": "0.14.3"
     }
   },
   "nbformat": 4,

--- a/docs/examples/mnist.ipynb
+++ b/docs/examples/mnist.ipynb
@@ -5,7 +5,7 @@
       "source": [
         "# Introduction to BNNs with Larq\n",
         "\n",
-        "**Run this notebook here: [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/plumerai/larq/master?filepath=docs%2Fexamples%2Fmnist.ipynb)**\n",
+        "<a href=\"https://mybinder.org/v2/gh/plumerai/larq/master?filepath=docs%2Fexamples%2Fmnist.ipynb\"><button data-md-color-primary=\"blue\">Run on Binder</button></a> <a href=\"https://github.com/plumerai/larq/blob/master/docs/examples/mnist.ipynb\"><button data-md-color-primary=\"blue\">View on GitHub</button></a>\n",
         "\n",
         "This tutorial demonstrates how to train a simple binarized Convolutional Neural Network (CNN) to classify MNIST digits. This simple network will achieve approximately 98% accuracy on the MNIST test set. This tutorial uses Larq and the [Keras Sequential API](https://www.tensorflow.org/guide/keras), so creating and training our model will require only a few lines of code."
       ],
@@ -308,7 +308,7 @@
       "file_extension": ".py"
     },
     "nteract": {
-      "version": "0.13.0"
+      "version": "0.14.3"
     }
   },
   "nbformat": 4,


### PR DESCRIPTION
#129 Made me realise that the Binder badge doesn't look really good on our docs page.

This will add a "Run on Binder" and "View on GitHub" button and change the appearance of our examples to
<img width="1221" alt="Bildschirmfoto 2019-07-09 um 11 23 44" src="https://user-images.githubusercontent.com/13285808/60880788-3f955700-a23c-11e9-80b5-2b226ad18ee5.png">

The buttons are note ideal, but I was able to add them without changing any CSS and I think they look better than what we are currently having.